### PR TITLE
Change target framework to v4.0

### DIFF
--- a/VortexSoft.Bootstrap/VortexSoft.Bootstrap.csproj
+++ b/VortexSoft.Bootstrap/VortexSoft.Bootstrap.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>VortexSoft.Bootstrap</RootNamespace>
     <AssemblyName>VortexSoft.Bootstrap</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>


### PR DESCRIPTION
This allows .NET 4.0 applications to use the package without needing to upgrade.

The project isn't using any .NET 4.5 features, so changing the target framework shouldn't cause any issues. I am using this on a production MVC4 application without issue, but am building the project locally to get a compatible DLL. It would be nice to have this update available in Nuget.
